### PR TITLE
remove babel register from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
   },
   "dependencies": {
     "@babel/core": "^7.0.0-beta.56",
-    "@babel/register": "^7.0.0-beta.56",
     "@types/jquery": "^3.3.5",
     "bootstrap": "^4.1.3",
     "i": "^0.3.6",


### PR DESCRIPTION
There is still an error message:
`[09:35:00] Failed to load external module @babel/register`
`[09:35:00] Requiring external module babel-register`
but after that npm builds the project without any trouble